### PR TITLE
Fix checksum validation for Swe

### DIFF
--- a/src/Format/SE.php
+++ b/src/Format/SE.php
@@ -92,6 +92,7 @@ class SE implements Vies
     }
 
     /**
+     * Luhn's algorithm: https://en.wikipedia.org/wiki/Luhn_algorithm
      * @param string $vatNumber
      *
      * @return bool
@@ -113,7 +114,7 @@ class SE implements Vies
         for ($index = 1; $index <= 7; $index += 2) {
             $sum += (int) $vatNumber[$index];
         }
-        $controlCode = 10 - $sum % 10;
+        $controlCode = (10 - $sum % 10) % 10;
 
         return $vatNumber[9] === (string) $controlCode;
     }

--- a/test/tests/Format/SETest.php
+++ b/test/tests/Format/SETest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class SETest extends TestCase
 {
-    public function testFormatShort(): void
+    public function testFormatShort()
     {
         $formatter = new SE();
         $formatted = $formatter->formatShort('SE556819238801');
@@ -30,7 +30,7 @@ class SETest extends TestCase
         $this->assertEquals('', $formatted);
     }
 
-    public function testFormatShortWithInvalidChecksum(): void
+    public function testFormatShortWithInvalidChecksum()
     {
         $formatter = new SE();
         $formatted = $formatter->formatShort('SE556819248801');

--- a/test/tests/Format/SETest.php
+++ b/test/tests/Format/SETest.php
@@ -2,8 +2,8 @@
 
 namespace VATLib\Test\Format;
 
-use VATLib\Format\SE;
 use PHPUnit\Framework\TestCase;
+use VATLib\Format\SE;
 
 class SETest extends TestCase
 {

--- a/test/tests/Format/SETest.php
+++ b/test/tests/Format/SETest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace VATLib\Test\Format;
+
+use VATLib\Format\SE;
+use PHPUnit\Framework\TestCase;
+
+class SETest extends TestCase
+{
+    public function testFormatShort(): void
+    {
+        $formatter = new SE();
+        $formatted = $formatter->formatShort('SE556819238801');
+        $this->assertEquals('556819238801', $formatted);
+    }
+
+    public function testFormatShortWithoutSEPrefix()
+    {
+        $formatter = new SE();
+        $formatted = $formatter->formatShort('556819238801');
+        $this->assertEquals('556819238801', $formatted);
+    }
+
+    public function testFormatShortWithInvalidTrailing()
+    {
+        $formatter = new SE();
+        $formatted = $formatter->formatShort('SE556819238800');
+        $this->assertEquals('', $formatted);
+        $formatted = $formatter->formatShort('SE556819238896');
+        $this->assertEquals('', $formatted);
+    }
+
+    public function testFormatShortWithInvalidChecksum(): void
+    {
+        $formatter = new SE();
+        $formatted = $formatter->formatShort('SE556819248801');
+        $this->assertEquals('', $formatted);
+    }
+}


### PR DESCRIPTION
The checkControlCode function for Sweden was missing the second modulo 10 of the Luhn algorithm, so it rejected VAT numbers incorrectly. I also added some tests to show it accepting a valid VAT-number and rejecting an invalid one